### PR TITLE
Fix the projects banners and add open to work

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -71,7 +71,7 @@ defineExpose({ setTheme });
 <style lang="scss" scoped>
 .portfolio {
 	position: relative;
-	padding: 7.5rem 6rem 3rem;
+	padding: 6.8rem 6rem 3rem;
 
 	.profile-section {
 		top: 0;

--- a/src/components/profile.vue
+++ b/src/components/profile.vue
@@ -26,6 +26,7 @@ const count = ref(0);
 						profile.address
 					}}</a>
 				</section>
+				<section class="status is-size-6 has-text-weight-bold text-highlight">(Open to Work)</section>
 			</div>
 		</div>
 		<Social />
@@ -68,7 +69,7 @@ const count = ref(0);
 	}
 	.button {
 		padding: 8px 50px;
-		margin-top: 70px;
+		margin-top: 40px;
 		background-color: var(--button-color);
 	}
 

--- a/src/views/Contact.vue
+++ b/src/views/Contact.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ErrorMessage, Field, Form } from 'vee-validate';
-import { onMounted, ref } from 'vue';
+import { ref } from 'vue';
 import * as yup from 'yup';
 
 import { type Contact, useAnalytics, useNotification } from '@/composables';

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -1,11 +1,28 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import { Card } from '@/components';
 import { misc, projects } from '@/config';
 import { type GitHubSchema } from '@/stores/misc/schema';
 
 const hoveredRepo = ref<string | null>(null);
 const repositories: GitHubSchema[] = misc.github.repositories;
+
+const preloadImage = (url: string): Promise<string> => {
+  return new Promise((resolve, reject) => {
+		const img = new Image();
+		img.src = url;
+		img.onload = () => resolve(url);
+		img.onerror = reject;
+  });
+};
+
+onMounted(async () => {
+  try {
+		await Promise.allSettled(repositories.map(repo => preloadImage(repo.banner)));
+  } catch {
+    throw Error('Failed to preload images for GitHub repositories');
+  }
+});
 </script>
 
 <template>


### PR DESCRIPTION
- Fixed the padding top to adjust the profile card and components
- Added a Open to Work text to covey the message | Fixed the Let's Talk button padding
- Removed the unused onMounted
- Added a preload functionality for the GitHub repo opengraphs